### PR TITLE
Fix build issues and update OS versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,42 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+FROM ubuntu:focal
 
 MAINTAINER bryan@turbojets.net
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DIST=ubuntu
-ENV RELEASE=trusty
+ENV RELEASE=focal
+
+# Install gnupg2
+RUN apt-get -q update && apt-get -y install gnupg2
 
 # Add Aptly repository
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 9E3E53F19C7DE460
+RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
 
 # Add Nginx repository
 RUN echo "deb http://nginx.org/packages/$DIST/ $RELEASE nginx" > /etc/apt/sources.list.d/nginx.list
 RUN echo "deb-src http://nginx.org/packages/$DIST/ $RELEASE nginx" >> /etc/apt/sources.list.d/nginx.list
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+
+# Update APT repository
+RUN apt-get -q update
 
 # Update APT repository and install packages
-RUN apt-get -q update                  \
- && apt-get -y install aptly           \
+RUN apt-get -y install aptly           \
                        bash-completion \
                        bzip2           \
-                       gnupg           \
+                       gnupg2          \
                        gpgv            \
                        graphviz        \
                        supervisor      \
                        nginx           \
                        wget            \
-                       xz-utils
+                       xz-utils        \
+                       vim-tiny
 
 # Install Aptly Configuration
 COPY assets/aptly.conf /etc/aptly.conf
 
 # Enable Aptly Bash completions
-RUN wget https://github.com/smira/aptly/raw/master/bash_completion.d/aptly \
-  -O /etc/bash_completion.d/aptly \
+RUN wget https://github.com/smira/aptly-fork/raw/master/completion.d/aptly \
+  -O /usr/share/bash-completion/completions/aptly \
   && echo "if ! shopt -oq posix; then\n\
   if [ -f /usr/share/bash-completion/bash_completion ]; then\n\
     . /usr/share/bash-completion/bash_completion\n\
@@ -65,8 +71,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 COPY assets/*.sh /opt/
 COPY assets/update_mirror/update_mirror_ubuntu.sh /opt/update_mirror.sh
 
-# Bind mount location
+# Bind mount locations
 VOLUME [ "/opt/aptly" ]
+VOLUME [ "/root/.gnupg" ]
 
 # Execute Startup script when container starts
 ENTRYPOINT [ "/opt/startup.sh" ]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -12,42 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:buster
 
 MAINTAINER bryan@turbojets.net
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DIST=debian
-ENV RELEASE=jessie
+ENV RELEASE=buster
+
+# Install gnupg2
+RUN apt-get -q update && apt-get -y install gnupg2
 
 # Add Aptly repository
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 9E3E53F19C7DE460
+RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
 
 # Add Nginx repository
 RUN echo "deb http://nginx.org/packages/$DIST/ $RELEASE nginx" > /etc/apt/sources.list.d/nginx.list
 RUN echo "deb-src http://nginx.org/packages/$DIST/ $RELEASE nginx" >> /etc/apt/sources.list.d/nginx.list
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+
+# Update APT repository
+RUN apt-get -q update
 
 # Update APT repository and install packages
-RUN apt-get -q update                  \
- && apt-get -y install aptly           \
+RUN apt-get -y install aptly           \
                        bash-completion \
                        bzip2           \
-                       gnupg           \
+                       gnupg2          \
                        gpgv            \
                        graphviz        \
                        supervisor      \
                        nginx           \
                        wget            \
-                       xz-utils
+                       xz-utils        \
+                       vim-tiny
 
 # Install Aptly Configuration
 COPY assets/aptly.conf /etc/aptly.conf
 
 # Enable Aptly Bash completions
-RUN wget https://github.com/smira/aptly/raw/master/bash_completion.d/aptly \
-  -O /etc/bash_completion.d/aptly \
+RUN wget https://github.com/smira/aptly-fork/raw/master/completion.d/aptly \
+  -O /usr/share/bash-completion/completions/aptly \
   && echo "if ! shopt -oq posix; then\n\
   if [ -f /usr/share/bash-completion/bash_completion ]; then\n\
     . /usr/share/bash-completion/bash_completion\n\
@@ -65,8 +71,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 COPY assets/*.sh /opt/
 COPY assets/update_mirror/update_mirror_debian.sh /opt/update_mirror.sh
 
-# Bind mount location
+# Bind mount locations
 VOLUME [ "/opt/aptly" ]
+VOLUME [ "/root/.gnupg" ]
 
 # Execute Startup script when container starts
 ENTRYPOINT [ "/opt/startup.sh" ]

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ docker run                                               \
 ```  
 run the container in the background  
 ```
---log-driver=syslog
-```  
-send nginx logs to syslog on the Docker host  (requires Docker 1.6 or higher)  
-```
 --name="aptly"
 ```  
 name of the container  
@@ -68,6 +64,10 @@ the hostname of the Docker host that this container is running on
 ```  
 path that aptly will use to store its data : mapped path in the container  
 ```
+--volume /dockerhost/dir/for/gpg/secrets:/root/.gnupg
+```
+path that will store gnu gpg keys used to sign published aptly repositories
+```
 --publish 80:80
 ```  
 Docker host port : mapped port in the container
@@ -75,8 +75,8 @@ Docker host port : mapped port in the container
 Create a mirror of Ubuntu's main repository
 --
 1. The initial download of the repository may take quite some time depending on your bandwidth limits, it may be in your best interest to open a screen or tmux session before proceeding.
-2. Attach to the container ```docker exec -it aptly /bin/bash```
-3. By default, ```/opt/update_mirror.sh``` will automate the creation of an Ubuntu 14.04 Trusty repository with the main and universe components, you can adjust the variables in the script to suit your needs.
+2. Attach to the container ```docker exec -it aptly /bin/bash``` or run ```shell.sh```
+3. By default, ```/opt/update_mirror.sh``` will automate the creation of an Ubuntu 20.04 "Focal" repository with the main and universe components, you can adjust the variables in the script to suit your needs.
 4. Run ```/opt/update_mirror.sh```
 5. If the script fails due to network disconnects etc, just re-run it.
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,43 +1,42 @@
 #! /bin/bash
 
 # If the repository GPG keypair doesn't exist, create it.
-if [[ ! -f /opt/aptly/aptly.sec ]] || [[ ! -f /opt/aptly/aptly.pub ]]; then
+if [[ ! -f /opt/aptly/aptly.pub ]]; then
   /opt/gpg_batch.sh
   # If your system doesn't have a lot of entropy this may, take a long time
   # Google how-to create "artificial" entropy if this gets stuck
-  gpg --batch --gen-key /opt/gpg_batch
+  gpg2 --batch --gen-key /opt/gpg_batch
+  chmod 700 ~/.gnupg
 fi
 
 # Export the GPG Public key
 if [[ ! -f /opt/aptly/public/aptly_repo_signing.key ]]; then
   mkdir -p /opt/aptly/public
-  gpg --export --armor > /opt/aptly/public/aptly_repo_signing.key
+  gpg2 --import /opt/aptly/aptly.pub
+  gpg2 --export --armor > /opt/aptly/public/aptly_repo_signing.key
 fi
 
 # Import Ubuntu keyrings if they exist
 if [[ -f /usr/share/keyrings/ubuntu-archive-keyring.gpg ]]; then
-  gpg --list-keys
-  gpg --no-default-keyring                                     \
-      --keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg \
-      --export |                                               \
-  gpg --no-default-keyring                                     \
-      --keyring trustedkeys.gpg                                \
-      --import
+  gpg2 --list-keys
+  gpg2 --no-default-keyring                                     \
+       --keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg \
+       --export |                                               \
+  gpg2 --no-default-keyring                                     \
+       --keyring trustedkeys.gpg                                \
+       --import
 fi
 
 # Import Debian keyrings if they exist
 if [[ -f /usr/share/keyrings/debian-archive-keyring.gpg ]]; then
-  gpg --list-keys
-  gpg --no-default-keyring                                     \
-      --keyring /usr/share/keyrings/debian-archive-keyring.gpg \
-      --export |                                               \
-  gpg --no-default-keyring                                     \
-      --keyring trustedkeys.gpg                                \
-      --import
+  gpg2 --list-keys
+  gpg2 --no-default-keyring                                     \
+       --keyring /usr/share/keyrings/debian-archive-keyring.gpg \
+       --export > /root/.gnupg/trustedkeys.gpg
 fi
 
 # Aptly looks in /root/.gnupg for default keyrings
-ln -sf /opt/aptly/aptly.sec /root/.gnupg/secring.gpg
+#ln -sf /opt/aptly/aptly.sec /root/.gnupg/secring.gpg
 ln -sf /opt/aptly/aptly.pub /root/.gnupg/pubring.gpg
 
 # Generate Nginx Config

--- a/assets/update_mirror/update_mirror_ubuntu.sh
+++ b/assets/update_mirror/update_mirror_ubuntu.sh
@@ -3,17 +3,29 @@ set -e
 
 # Automate the initial creation and update of an Ubuntu package mirror in aptly
 
-# The variables (as set below) will create a mirror of the Ubuntu Trusty repo 
+# The variables (as set below) will create a mirror of the Ubuntu Focal repo
 # with the main & universe components, you can add other components like restricted
 # multiverse etc by adding to the array (separated by spaces).
 
 # For more detail about each of the variables below refer to: 
 # https://help.ubuntu.com/community/Repositories/CommandLine
 
-UBUNTU_RELEASE=trusty
+UBUNTU_RELEASE=focal
 UPSTREAM_URL="http://archive.ubuntu.com/ubuntu/"
 COMPONENTS=( main universe )
 REPOS=( ${UBUNTU_RELEASE} ${UBUNTU_RELEASE}-updates ${UBUNTU_RELEASE}-security )
+
+# Setup gpg-agent to cache GPG passphrase for unattended operation
+# Allow passphrase preset for unattended updates
+if [[ ! -f ~/.gnupg/gpg-agent.conf ]]; then
+  echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
+  pkill -SIGTERM gpg-agent
+fi
+
+gpg-agent --homedir /root/.gnupg --daemon || true
+gpg2 --import /opt/aptly/aptly.pub
+KG=`gpg2 --list-keys --with-keygrip | awk '/rsa2048/{getline; getline; print $3}'`
+echo "$GPG_PASSWORD" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$KG"
 
 # Create repository mirrors if they don't exist
 set +e
@@ -41,8 +53,8 @@ done
 for component in ${COMPONENTS[@]}; do
   for repo in ${REPOS[@]}; do
     echo "Creating snapshot of ${repo}-${component} repository mirror.."
-    SNAPSHOTARRAY+="${repo}-${component}-`date +%Y%m%d%H` "
-    aptly snapshot create ${repo}-${component}-`date +%Y%m%d%H` from mirror ${repo}-${component}
+    SNAPSHOTARRAY+="${repo}-${component}-`date +%Y%m%d%H%M` "
+    aptly snapshot create ${repo}-${component}-`date +%Y%m%d%H%M` from mirror ${repo}-${component}
   done
 done
 
@@ -51,7 +63,7 @@ echo ${SNAPSHOTARRAY[@]}
 # Merge snapshots into a single snapshot with updates applied
 echo "Merging snapshots into one.." 
 aptly snapshot merge -latest                 \
-  ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H`  \
+  ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H%M`  \
   ${SNAPSHOTARRAY[@]}
 
 # Publish the latest merged snapshot
@@ -59,17 +71,16 @@ set +e
 aptly publish list -raw | awk '{print $2}' | grep "^${UBUNTU_RELEASE}$"
 if [[ $? -eq 0 ]]; then
   aptly publish switch            \
-    -passphrase="${GPG_PASSWORD}" \
-    ${UBUNTU_RELEASE} ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H`
+    ${UBUNTU_RELEASE} ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H%M`
 else
   aptly publish snapshot \
-    -passphrase="${GPG_PASSWORD}" \
-    -distribution=${UBUNTU_RELEASE} ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H`
+    -distribution=${UBUNTU_RELEASE} ${UBUNTU_RELEASE}-merged-`date +%Y%m%d%H%M`
 fi
 set -e
 
 # Export the GPG Public key
 if [[ ! -f /opt/aptly/public/aptly_repo_signing.key ]]; then
+  gpg2 --import /opt/aptly/aptly.pub
   gpg --export --armor > /opt/aptly/public/aptly_repo_signing.key
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,6 @@ echo
 echo -n "Container ID: "
 docker run \
 --detach=true \
---log-driver=syslog \
 --name="${APP_NAME}" \
 --restart=always \
 -e FULL_NAME="${FULL_NAME}" \
@@ -25,9 +24,11 @@ docker run \
 -e GPG_PASSWORD="${GPG_PASSWORD}" \
 -e HOSTNAME="${HOSTNAME}" \
 -v ${APTLY_DATADIR}:/opt/aptly \
+-v ${GPG_DATA}:/root/.gnupg \
 -p ${DOCKER_HOST_PORT}:80 \
 ${LATESTIMAGE}
 # Other useful options
+#--log-driver=syslog \ # if you want Docker logs to go to syslog (Linux)
 # -p DOCKERHOST_PORT:CONTAINER_PORT \
 # -e "ENVIRONMENT_VARIABLE_NAME=VALUE" \
 # -v /DOCKERHOST/PATH:/CONTAINER/PATH \

--- a/vars
+++ b/vars
@@ -15,6 +15,8 @@ EMAIL_ADDRESS=user@example.com
 GPG_PASSWORD=repo1234
 # The directory on the Docker host to store repository data
 APTLY_DATADIR=/tmp/path/to/lots/of/space
+# The directory on the Docker host to store gpg keys
+GPG_DATA=/tmp/path/to/secure/place
 # FQDN of the Docker host that the aptly container will run on 
 HOSTNAME=aptly.example.com
 # TCP port that aptly will be reachable on, set to something else if you already


### PR DESCRIPTION
looks like some folks are still finding this repo so updating to:

* update to ubuntu 20.04 focal repositories/image
* upgrade to gnupg2
* updated nginx keyserver keys
* updated aptly keyserver keys 
* fix aptly BASH completion destination location
* add minutes to aptly published names
* use gpg-preset-passphrase to store gpg key password for unattended updates 
* remove log driver syslog to enable hosting on other than Linux platforms
* bind mount gpg keys to preserve them if container is deleted