### PR TITLE
Update keyserver to keyserver.ubuntu.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,12 @@ RUN apt-get -q update && apt-get -y install gnupg2
 
 # Add Aptly repository
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list
-RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
+RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys A0546A43624A8331
 
 # Add Nginx repository
 RUN echo "deb http://nginx.org/packages/$DIST/ $RELEASE nginx" > /etc/apt/sources.list.d/nginx.list
 RUN echo "deb-src http://nginx.org/packages/$DIST/ $RELEASE nginx" >> /etc/apt/sources.list.d/nginx.list
-RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62
 
 # Update APT repository
 RUN apt-get -q update

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -25,12 +25,12 @@ RUN apt-get -q update && apt-get -y install gnupg2
 
 # Add Aptly repository
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list
-RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
+RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys A0546A43624A8331
 
 # Add Nginx repository
 RUN echo "deb http://nginx.org/packages/$DIST/ $RELEASE nginx" > /etc/apt/sources.list.d/nginx.list
 RUN echo "deb-src http://nginx.org/packages/$DIST/ $RELEASE nginx" >> /etc/apt/sources.list.d/nginx.list
-RUN apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62
 
 # Update APT repository
 RUN apt-get -q update


### PR DESCRIPTION
The sks-keyservers.net were taken offline, so this will update to the current 2022 keys.

NOTE: On my configuration I had to use hkp://keyserver.ubuntu.com:80 because of firewall issues.